### PR TITLE
Features/command substitution

### DIFF
--- a/lib/yap/shell/evaluation.rb
+++ b/lib/yap/shell/evaluation.rb
@@ -31,7 +31,7 @@ module Yap::Shell
           r,w = IO.pipe
           @stdout = w
           ast.accept(self)
-          input[position.min..position.max] = r.read.chomp
+          input[position.min...position.max] = r.read.chomp
         end
       end
       input


### PR DESCRIPTION
This includes basic support for command substitution and expansion. It is similar to how bash command substitution works:

```
echo `echo hi` && echo $(echo bye) && echo `echo $(echo something nested)`
```

However, it has a few differences. If the command in the command substitution fails then it will short-circuit out, e.g.:

```
yap> echo `bad-command` hi
CommandError: Don't know how to execute command: bad-command
```

However in bash, it continues on:

```
bash> echo `bad-command` hi
bash: bad-command: command not found
hi
```

Bash's behavior is potentially dangerous because it allows a conditional pipeline to behave in a nonintuitive manner, e.g. :

```
bash> echo `bad-command` && echo "both commands succeed"
bash: bad-command: command not found

both commands succeed
```

In yap, we avoid that oddity:

```
yap> echo `bad-command` && echo "both commands succeed"
CommandError: Don't know how to execute command: bad-command
```

There may be a use case bash's behavior, but I have yet to hit it. I have however spent time debugging subcommand failures because it failed when it looked like it have succeeded.