### PR TITLE
Features/env vars

### DIFF
--- a/lib/yap/shell/evaluation.rb
+++ b/lib/yap/shell/evaluation.rb
@@ -51,7 +51,7 @@ module Yap::Shell
     def visit_CommandNode(node)
       @aliases_expanded ||= []
       with_standard_streams do |stdin, stdout, stderr|
-        args = node.args.map(&:lvalue)
+        args = node.args.map(&:lvalue).map{ |arg| env_expand(arg) }
         if !node.literal? && !@aliases_expanded.include?(node.command) && _alias=Aliases.instance.fetch_alias(node.command)
           @suppress_events = true
           ast = Yap::Shell::Parser.new.parse([_alias].concat(args).join(" "))
@@ -60,8 +60,9 @@ module Yap::Shell
           @aliases_expanded.pop
           @suppress_events = false
         else
+          cmd2execute = env_expand(node.command)
           command = CommandFactory.build_command_for(
-            command: node.command,
+            command: cmd2execute,
             args:    shell_expand(args),
             heredoc: node.heredoc,
             internally_evaluate: node.internally_evaluate?)
@@ -159,6 +160,18 @@ module Yap::Shell
         [new_head].concat(tail).join(" ")
       else
         input
+      end
+    end
+
+    def env_expand(input)
+      input.gsub(/\$(\w+)/) do |match,*args|
+        var_name = match[1..-1]
+        case var_name
+        when "$?"
+          @last_result ? @last_result.status_code.to_s : '0'
+        else
+          ENV.fetch(var_name){ match }
+        end
       end
     end
 


### PR DESCRIPTION

Improving support for ENV variables.

Setting ENV vars in a standalone statement will result in persisting the change to the shell's environment, e.g.:

    yap> A=1
    yap> echo $A
    1
    yap> A=2 && echo $A
    2
    yap> echo $A
    2
    yap> A=3 B=4
    yap> echo $A != $B
    3 != 4

However, ENV vars scopes to a statement will only exist for that statement and then they will be rolled back:

    yap> A=1
    yap> A=5 echo $A
    5
    yap> echo $A
    1

This breaks compatibility with bash/dash/zsh because it's what I'd expect to happen. :)

For example, bash/zsh/dash does not make environment variables available to builtins right away. It waits until a child process is forked, e.g.:

    bash/zsh/dash> A=5 echo $A                    # <-- uses shell builtin
    bash/zsh/dash> A=5 ruby -e 'puts ENV["A"]'    # <-- forks and creates ruby subprocess
    5

Note: this commits removes reverting the ENV in visit_StatementsNode because that would cause all environment changes to be reverted. We don't want that, we want EnvNode(s) being visited to persist while EnvWrapperNode(s) should revert.